### PR TITLE
feat(ui): Introduce PureBlack switch on dark theme

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/MainApplication.kt
+++ b/app/src/main/kotlin/app/vitune/android/MainApplication.kt
@@ -87,6 +87,7 @@ import app.vitune.core.ui.SystemBarAppearance
 import app.vitune.core.ui.appearance
 import app.vitune.core.ui.dynamicColorPaletteOf
 import app.vitune.core.ui.enums.ColorPaletteName
+import app.vitune.core.ui.isPureBlackAvailable
 import app.vitune.core.ui.rippleTheme
 import app.vitune.core.ui.shimmerTheme
 import app.vitune.providers.innertube.Innertube
@@ -163,6 +164,8 @@ class MainActivity : ComponentActivity(), MonetColorsChangedListener {
         val appearance = appearance(
             name = colorPaletteName,
             mode = colorPaletteMode,
+            usePureBlack = usePureBlack &&
+                isPureBlackAvailable(colorPaletteName, colorPaletteMode),
             fontFamily = fontFamily,
             materialAccentColor = Color(monet.getAccentColor(this@MainActivity)),
             sampleBitmap = sampleBitmap,

--- a/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
@@ -9,7 +9,7 @@ import app.vitune.core.ui.enums.ThumbnailRoundness
 object AppearancePreferences : GlobalPreferencesHolder() {
     var colorPaletteName by enum(ColorPaletteName.Dynamic)
     var colorPaletteMode by enum(ColorPaletteMode.System)
-    var usePureBlack by boolean(false)
+    var usePureBlack by boolean(if (colorPaletteName == ColorPaletteName.PureBlack) true else false)
     var thumbnailRoundness by enum(ThumbnailRoundness.Medium)
     var fontFamily by enum(BuiltInFontFamily.Poppins)
     var applyFontPadding by boolean(false)

--- a/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
@@ -9,6 +9,7 @@ import app.vitune.core.ui.enums.ThumbnailRoundness
 object AppearancePreferences : GlobalPreferencesHolder() {
     var colorPaletteName by enum(ColorPaletteName.Dynamic)
     var colorPaletteMode by enum(ColorPaletteMode.System)
+    var usePureBlack by boolean(false)
     var thumbnailRoundness by enum(ThumbnailRoundness.Medium)
     var fontFamily by enum(BuiltInFontFamily.Poppins)
     var applyFontPadding by boolean(false)

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/player/Lyrics.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/player/Lyrics.kt
@@ -312,7 +312,7 @@ fun Lyrics(
                 BasicText(
                     text = if (isShowingSynchronizedLyrics) stringResource(R.string.error_load_synchronized_lyrics)
                     else stringResource(R.string.error_load_lyrics),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(PureBlackColorPalette().text),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -329,7 +329,7 @@ fun Lyrics(
                 BasicText(
                     text = if (isShowingSynchronizedLyrics) stringResource(R.string.synchronized_lyrics_not_available)
                     else stringResource(R.string.lyrics_not_available),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(PureBlackColorPalette().text),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -345,7 +345,7 @@ fun Lyrics(
             ) {
                 BasicText(
                     text = stringResource(R.string.invalid_synchronized_lyrics),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(PureBlackColorPalette().text),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -424,7 +424,7 @@ fun Lyrics(
                     }
                 } else BasicText(
                     text = text,
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(PureBlackColorPalette().text),
                     modifier = Modifier
                         .verticalFadingEdge()
                         .verticalScroll(rememberScrollState())

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/player/PlaybackError.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/player/PlaybackError.kt
@@ -66,7 +66,7 @@ fun PlaybackError(
     ) { currentMessage ->
         if (currentMessage != null) BasicText(
             text = currentMessage,
-            style = LocalAppearance.current.typography.xs.center.medium.color(PureBlackColorPalette.text),
+            style = LocalAppearance.current.typography.xs.center.medium.color(PureBlackColorPalette().text),
             modifier = Modifier
                 .background(Color.Black.copy(0.4f))
                 .padding(all = 8.dp)

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
@@ -212,6 +212,7 @@ val ColorPaletteName.nameLocalized
             ColorPaletteName.Dynamic -> R.string.theme_name_dynamic
             ColorPaletteName.AMOLED -> R.string.theme_name_amoled
             ColorPaletteName.MaterialYou -> R.string.theme_name_materialyou
+            ColorPaletteName.PureBlack -> R.string.theme_name_pureblack
         }
     )
 

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
@@ -18,11 +18,12 @@ import app.vitune.android.utils.currentLocale
 import app.vitune.android.utils.findActivity
 import app.vitune.android.utils.startLanguagePicker
 import app.vitune.core.ui.BuiltInFontFamily
+import app.vitune.core.ui.googleFontsAvailable
+import app.vitune.core.ui.isPureBlackAvailable
 import app.vitune.core.ui.LocalAppearance
 import app.vitune.core.ui.enums.ColorPaletteMode
 import app.vitune.core.ui.enums.ColorPaletteName
 import app.vitune.core.ui.enums.ThumbnailRoundness
-import app.vitune.core.ui.googleFontsAvailable
 import app.vitune.core.ui.utils.isAtLeastAndroid13
 
 @Route
@@ -43,11 +44,20 @@ fun AppearanceSettings() = with(AppearancePreferences) {
             EnumValueSelectorSettingsEntry(
                 title = stringResource(R.string.theme_mode),
                 selectedValue = colorPaletteMode,
-                isEnabled = colorPaletteName != ColorPaletteName.PureBlack &&
-                        colorPaletteName != ColorPaletteName.AMOLED,
+                isEnabled = colorPaletteName != ColorPaletteName.AMOLED,
                 onValueSelected = { colorPaletteMode = it },
                 valueText = { it.nameLocalized }
             )
+
+            AnimatedVisibility(
+                visible = isPureBlackAvailable(colorPaletteName, colorPaletteMode),
+                label = ""
+            ) { SwitchSettingsEntry(
+                title = stringResource(R.string.theme_name_pureblack),
+                text = "",
+                isChecked = usePureBlack,
+                onCheckedChange = { usePureBlack = it }
+            ) }
         }
         SettingsGroup(title = stringResource(R.string.shapes)) {
             EnumValueSelectorSettingsEntry(
@@ -200,7 +210,6 @@ val ColorPaletteName.nameLocalized
         when (this) {
             ColorPaletteName.Default -> R.string.theme_name_default
             ColorPaletteName.Dynamic -> R.string.theme_name_dynamic
-            ColorPaletteName.PureBlack -> R.string.theme_name_pureblack
             ColorPaletteName.AMOLED -> R.string.theme_name_amoled
             ColorPaletteName.MaterialYou -> R.string.theme_name_materialyou
         }

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/Appearance.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/Appearance.kt
@@ -80,7 +80,8 @@ fun appearance(
     sampleBitmap: Bitmap?,
     applyFontPadding: Boolean,
     thumbnailRoundness: Dp,
-    isSystemInDarkTheme: Boolean = isSystemInDarkTheme()
+    isSystemInDarkTheme: Boolean = isSystemInDarkTheme(),
+    usePureBlack: Boolean
 ): Appearance {
     val isDark = remember(mode, isSystemInDarkTheme) {
         mode == ColorPaletteMode.Dark || (mode == ColorPaletteMode.System && isSystemInDarkTheme)
@@ -142,7 +143,6 @@ fun appearance(
                     isAmoled = false
                 )
 
-                ColorPaletteName.PureBlack -> PureBlackColorPalette
                 ColorPaletteName.AMOLED -> dynamicColorPaletteOf(
                     hsl = dynamicAccentColor,
                     isDark = true,
@@ -156,15 +156,24 @@ fun appearance(
         colorPalette,
         defaultTheme,
         thumbnailRoundness,
+        usePureBlack,
         isDark = isDark
     ) {
         Appearance(
-            colorPalette = colorPalette,
+            colorPalette = if (usePureBlack) PureBlackColorPalette else colorPalette,
             typography = defaultTheme.typography.copy(color = colorPalette.text),
             thumbnailShapeCorners = thumbnailRoundness
         )
     }.value
 }
+
+@Composable
+fun isPureBlackAvailable(
+    colorPaletteName: ColorPaletteName,
+    colorPaletteMode: ColorPaletteMode
+) = colorPaletteName == ColorPaletteName.AMOLED
+        || colorPaletteMode == ColorPaletteMode.Dark
+        || (colorPaletteMode == ColorPaletteMode.System && isSystemInDarkTheme())
 
 fun Activity.setSystemBarAppearance(isDark: Boolean) {
     with(WindowCompat.getInsetsController(window, window.decorView.rootView)) {

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/Appearance.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/Appearance.kt
@@ -143,6 +143,7 @@ fun appearance(
                     isAmoled = false
                 )
 
+                ColorPaletteName.PureBlack -> PureBlackColorPalette()
                 ColorPaletteName.AMOLED -> dynamicColorPaletteOf(
                     hsl = dynamicAccentColor,
                     isDark = true,
@@ -160,7 +161,10 @@ fun appearance(
         isDark = isDark
     ) {
         Appearance(
-            colorPalette = if (usePureBlack) PureBlackColorPalette else colorPalette,
+            // NOTE(dtomvan): When using pure black we modify the current
+            // ColorPallette to behave in our new way. NO-OP if user is using
+            // the "normal" pure black palette.
+            colorPalette = if (usePureBlack) PureBlackColorPalette(colorPalette) else colorPalette,
             typography = defaultTheme.typography.copy(color = colorPalette.text),
             thumbnailShapeCorners = thumbnailRoundness
         )

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/ColorPalette.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/ColorPalette.kt
@@ -29,7 +29,7 @@ data class ColorPalette(
         override fun restore(value: List<Any>) = when (val accent = value[0] as Int) {
             0 -> DefaultDarkColorPalette
             1 -> DefaultLightColorPalette
-            2 -> PureBlackColorPalette
+            2 -> PureBlackColorPalette()
             else -> dynamicColorPaletteOf(
                 accentColor = Color(accent),
                 isDark = value[1] as Boolean,
@@ -41,7 +41,7 @@ data class ColorPalette(
             when {
                 value === DefaultDarkColorPalette -> 0
                 value === DefaultLightColorPalette -> 1
-                value === PureBlackColorPalette -> 2
+                value === PureBlackColorPalette() -> 2
                 else -> value.accent.toArgb()
             },
             value.isDark,
@@ -76,7 +76,9 @@ val DefaultLightColorPalette = ColorPalette(
     isAmoled = false
 )
 
-val PureBlackColorPalette = DefaultDarkColorPalette.copy(
+fun PureBlackColorPalette(
+    p: ColorPalette = DefaultDarkColorPalette
+) = p.copy(
     background0 = Color.Black,
     background1 = Color.Black,
     background2 = Color.Black
@@ -94,7 +96,8 @@ fun colorPaletteOf(
         ColorPaletteMode.System -> if (isDark) DefaultDarkColorPalette else DefaultLightColorPalette
     }
 
-    ColorPaletteName.AMOLED -> PureBlackColorPalette.copy(isAmoled = true)
+    ColorPaletteName.PureBlack -> PureBlackColorPalette()
+    ColorPaletteName.AMOLED -> PureBlackColorPalette().copy(isAmoled = true)
 }
 
 fun dynamicAccentColorOf(
@@ -140,7 +143,7 @@ fun dynamicColorPaletteOf(
         lightness = 0.5f
     )
 
-    if (isAmoled) PureBlackColorPalette.copy(
+    if (isAmoled) PureBlackColorPalette().copy(
         isAmoled = true,
         accent = accentColor
     ) else colorPaletteOf(
@@ -194,20 +197,20 @@ fun dynamicColorPaletteOf(
 
 inline val ColorPalette.isDefault
     get() =
-        this === DefaultDarkColorPalette || this === DefaultLightColorPalette || this === PureBlackColorPalette
+        this === DefaultDarkColorPalette || this === DefaultLightColorPalette || this === PureBlackColorPalette()
 
 inline val ColorPalette.collapsedPlayerProgressBar get() =
-    if (this === PureBlackColorPalette) DefaultDarkColorPalette.background0 else background2
+    if (this === PureBlackColorPalette()) DefaultDarkColorPalette.background0 else background2
 inline val ColorPalette.favoritesIcon get() = if (isDefault) red else accent
 inline val ColorPalette.shimmer get() = if (isDefault) Color(0xff838383) else accent
 inline val ColorPalette.primaryButton
-    get() = if (this === PureBlackColorPalette || isAmoled) Color(0xFF272727) else background2
+    get() = if (this === PureBlackColorPalette() || isAmoled) Color(0xFF272727) else background2
 
 @Suppress("UnusedReceiverParameter")
-inline val ColorPalette.overlay get() = PureBlackColorPalette.background0.copy(alpha = 0.75f)
+inline val ColorPalette.overlay get() = PureBlackColorPalette().background0.copy(alpha = 0.75f)
 
 @Suppress("UnusedReceiverParameter")
-inline val ColorPalette.onOverlay get() = PureBlackColorPalette.text
+inline val ColorPalette.onOverlay get() = PureBlackColorPalette().text
 
 @Suppress("UnusedReceiverParameter")
-inline val ColorPalette.onOverlayShimmer get() = PureBlackColorPalette.shimmer
+inline val ColorPalette.onOverlayShimmer get() = PureBlackColorPalette().shimmer

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/ColorPalette.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/ColorPalette.kt
@@ -94,7 +94,6 @@ fun colorPaletteOf(
         ColorPaletteMode.System -> if (isDark) DefaultDarkColorPalette else DefaultLightColorPalette
     }
 
-    ColorPaletteName.PureBlack -> PureBlackColorPalette
     ColorPaletteName.AMOLED -> PureBlackColorPalette.copy(isAmoled = true)
 }
 

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
@@ -4,6 +4,5 @@ enum class ColorPaletteName(val isDynamic: Boolean) {
     Default(isDynamic = false),
     Dynamic(isDynamic = true),
     MaterialYou(isDynamic = true),
-    PureBlack(isDynamic = false),
     AMOLED(isDynamic = true)
 }

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
@@ -4,5 +4,6 @@ enum class ColorPaletteName(val isDynamic: Boolean) {
     Default(isDynamic = false),
     Dynamic(isDynamic = true),
     MaterialYou(isDynamic = true),
+    PureBlack(isDynamic = false),
     AMOLED(isDynamic = true)
 }


### PR DESCRIPTION
This works freely on any theme that has dark colors (as of now: AMOLED,
Dark, System while in dark mode) while using any "base theme".

NOTE: I don\'t know if me and @25huizengek1 are entirely happy on the behaviour
but man, this theme stuff sure is difficult isn\'t it? Also my first time using
Kotlin for Android apps with Compose, so I hope the code looks good enough. I
don't know which formatter I should be using, so I used none but tried to indent
cleanly by myselves (looks like 4 spaces across the board).

@jojobozo, does this look good to you?

Resolves: #142
