### PR TITLE
chore: add git hook for detekt

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+./gradlew detekt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
     alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.detekt)
+
+    id("com.gtramontina.ghooks.gradle") version "2.0.0" // version omitted, won't really ever change...
 }
 
 val clean by tasks.registering(Delete::class) {


### PR DESCRIPTION
In PR #214, I said:

> I don't know which formatter I should be using, so I used none but tried to
> indent cleanly by myselves (looks like 4 spaces across the board).

So I figured I should just include a git hook for it. It:

- works for all platforms (win,mac,lin) because of powershell core
- works through gradle, so no additional "commit hook installer" dependencies
needed here
- "just" runs detekt, doesn't disallow pushing, just suggests the contributor to
  push clearer code
- transparently adds itself when any gradle task is invoked for the first time

NOTE: the code doesn't appear entirely formatted as of now, but I'm sure we
could fix that. I don't think detekt can automatically fix unformatted code but
I think we could include settings for IDEA which mirror the formatting rules
detekt is checking for.

Also, I think we should include a reference to this in the upcoming CONTRIBUTING.md file: #195 
