### PR TITLE
feat(ui): Rewrite color palette logic

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/MainApplication.kt
+++ b/app/src/main/kotlin/app/vitune/android/MainApplication.kt
@@ -81,12 +81,12 @@ import app.vitune.android.utils.toast
 import app.vitune.compose.persist.LocalPersistMap
 import app.vitune.compose.persist.PersistMap
 import app.vitune.compose.preferences.PreferencesHolder
+import app.vitune.core.ui.Darkness
 import app.vitune.core.ui.Dimensions
 import app.vitune.core.ui.LocalAppearance
 import app.vitune.core.ui.SystemBarAppearance
+import app.vitune.core.ui.amoled
 import app.vitune.core.ui.appearance
-import app.vitune.core.ui.dynamicColorPaletteOf
-import app.vitune.core.ui.enums.ColorPaletteName
 import app.vitune.core.ui.rippleTheme
 import app.vitune.core.ui.shimmerTheme
 import app.vitune.providers.innertube.Innertube
@@ -161,8 +161,9 @@ class MainActivity : ComponentActivity(), MonetColorsChangedListener {
     ) = with(AppearancePreferences) {
         val sampleBitmap by binder.collectProvidedBitmapAsState()
         val appearance = appearance(
-            name = colorPaletteName,
-            mode = colorPaletteMode,
+            source = colorSource,
+            mode = colorMode,
+            darkness = darkness,
             fontFamily = fontFamily,
             materialAccentColor = Color(monet.getAccentColor(this@MainActivity)),
             sampleBitmap = sampleBitmap,
@@ -258,15 +259,9 @@ class MainActivity : ComponentActivity(), MonetColorsChangedListener {
 
                     CompositionLocalProvider(
                         LocalAppearance provides LocalAppearance.current.let {
-                            if (
-                                AppearancePreferences.colorPaletteName == ColorPaletteName.AMOLED
-                            ) it.copy(
-                                colorPalette = dynamicColorPaletteOf(
-                                    accentColor = it.colorPalette.accent,
-                                    isDark = true,
-                                    isAmoled = false
-                                )
-                            ) else it
+                            if (it.colorPalette.isDark && AppearancePreferences.darkness == Darkness.AMOLED) {
+                                it.copy(colorPalette = it.colorPalette.amoled())
+                            } else it
                         }
                     ) {
                         Player(

--- a/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
@@ -1,14 +1,36 @@
 package app.vitune.android.preferences
 
 import app.vitune.android.GlobalPreferencesHolder
+import app.vitune.android.preferences.OldPreferences.ColorPaletteMode
+import app.vitune.android.preferences.OldPreferences.ColorPaletteName
 import app.vitune.core.ui.BuiltInFontFamily
-import app.vitune.core.ui.enums.ColorPaletteMode
-import app.vitune.core.ui.enums.ColorPaletteName
-import app.vitune.core.ui.enums.ThumbnailRoundness
+import app.vitune.core.ui.ColorMode
+import app.vitune.core.ui.ColorSource
+import app.vitune.core.ui.Darkness
+import app.vitune.core.ui.ThumbnailRoundness
 
 object AppearancePreferences : GlobalPreferencesHolder() {
-    var colorPaletteName by enum(ColorPaletteName.Dynamic)
-    var colorPaletteMode by enum(ColorPaletteMode.System)
+    var colorSource by enum(
+        when (OldPreferences.oldColorPaletteName) {
+            ColorPaletteName.Default, ColorPaletteName.PureBlack -> ColorSource.Default
+            ColorPaletteName.Dynamic, ColorPaletteName.AMOLED -> ColorSource.Dynamic
+            ColorPaletteName.MaterialYou -> ColorSource.MaterialYou
+        }
+    )
+    var colorMode by enum(
+        when (OldPreferences.oldColorPaletteMode) {
+            ColorPaletteMode.Light -> ColorMode.Light
+            ColorPaletteMode.Dark -> ColorMode.Dark
+            ColorPaletteMode.System -> ColorMode.System
+        }
+    )
+    var darkness by enum(
+        when (OldPreferences.oldColorPaletteName) {
+            ColorPaletteName.Default, ColorPaletteName.Dynamic, ColorPaletteName.MaterialYou -> Darkness.Normal
+            ColorPaletteName.PureBlack -> Darkness.PureBlack
+            ColorPaletteName.AMOLED -> Darkness.AMOLED
+        }
+    )
     var thumbnailRoundness by enum(ThumbnailRoundness.Medium)
     var fontFamily by enum(BuiltInFontFamily.Poppins)
     var applyFontPadding by boolean(false)

--- a/app/src/main/kotlin/app/vitune/android/preferences/OldPreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/OldPreferences.kt
@@ -1,0 +1,22 @@
+package app.vitune.android.preferences
+
+import app.vitune.android.GlobalPreferencesHolder
+
+internal object OldPreferences : GlobalPreferencesHolder() {
+    val oldColorPaletteName by enum(ColorPaletteName.Dynamic, "colorPaletteName")
+    val oldColorPaletteMode by enum(ColorPaletteMode.System, "colorPaletteMode")
+
+    enum class ColorPaletteName {
+        Default,
+        Dynamic,
+        MaterialYou,
+        PureBlack,
+        AMOLED
+    }
+
+    enum class ColorPaletteMode {
+        Light,
+        Dark,
+        System
+    }
+}

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/player/Lyrics.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/player/Lyrics.kt
@@ -75,10 +75,10 @@ import app.vitune.android.utils.disabled
 import app.vitune.android.utils.medium
 import app.vitune.android.utils.semiBold
 import app.vitune.android.utils.toast
-import app.vitune.core.ui.DefaultDarkColorPalette
 import app.vitune.core.ui.LocalAppearance
-import app.vitune.core.ui.PureBlackColorPalette
+import app.vitune.core.ui.onOverlay
 import app.vitune.core.ui.onOverlayShimmer
+import app.vitune.core.ui.overlay
 import app.vitune.providers.innertube.Innertube
 import app.vitune.providers.innertube.models.bodies.NextBody
 import app.vitune.providers.innertube.requests.lyrics
@@ -301,7 +301,7 @@ fun Lyrics(
                     detectTapGestures(onTap = { onDismiss() })
                 }
                 .fillMaxSize()
-                .background(Color.Black.copy(0.8f))
+                .background(colorPalette.overlay)
         ) {
             AnimatedVisibility(
                 visible = isError && text == null,
@@ -312,7 +312,7 @@ fun Lyrics(
                 BasicText(
                     text = if (isShowingSynchronizedLyrics) stringResource(R.string.error_load_synchronized_lyrics)
                     else stringResource(R.string.error_load_lyrics),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(colorPalette.onOverlay),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -329,7 +329,7 @@ fun Lyrics(
                 BasicText(
                     text = if (isShowingSynchronizedLyrics) stringResource(R.string.synchronized_lyrics_not_available)
                     else stringResource(R.string.lyrics_not_available),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(colorPalette.onOverlay),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -345,7 +345,7 @@ fun Lyrics(
             ) {
                 BasicText(
                     text = stringResource(R.string.invalid_synchronized_lyrics),
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(colorPalette.onOverlay),
                     modifier = Modifier
                         .background(Color.Black.copy(0.4f))
                         .padding(all = 8.dp)
@@ -424,7 +424,7 @@ fun Lyrics(
                     }
                 } else BasicText(
                     text = text,
-                    style = typography.xs.center.medium.color(PureBlackColorPalette.text),
+                    style = typography.xs.center.medium.color(colorPalette.onOverlay),
                     modifier = Modifier
                         .verticalFadingEdge()
                         .verticalScroll(rememberScrollState())
@@ -448,7 +448,7 @@ fun Lyrics(
             Image(
                 painter = painterResource(R.drawable.ellipsis_horizontal),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(DefaultDarkColorPalette.text),
+                colorFilter = ColorFilter.tint(colorPalette.onOverlay),
                 modifier = Modifier
                     .padding(all = 4.dp)
                     .clickable(

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/player/PlaybackError.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/player/PlaybackError.kt
@@ -26,7 +26,8 @@ import app.vitune.android.utils.center
 import app.vitune.android.utils.color
 import app.vitune.android.utils.medium
 import app.vitune.core.ui.LocalAppearance
-import app.vitune.core.ui.PureBlackColorPalette
+import app.vitune.core.ui.onOverlay
+import app.vitune.core.ui.overlay
 
 @Composable
 fun PlaybackError(
@@ -35,6 +36,7 @@ fun PlaybackError(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) = Box(modifier = modifier) {
+    val (colorPalette, typography) = LocalAppearance.current
     val message by rememberUpdatedState(newValue = messageProvider())
 
     AnimatedVisibility(
@@ -66,9 +68,9 @@ fun PlaybackError(
     ) { currentMessage ->
         if (currentMessage != null) BasicText(
             text = currentMessage,
-            style = LocalAppearance.current.typography.xs.center.medium.color(PureBlackColorPalette.text),
+            style = typography.xs.center.medium.color(colorPalette.onOverlay),
             modifier = Modifier
-                .background(Color.Black.copy(0.4f))
+                .background(colorPalette.overlay.copy(alpha = 0.4f))
                 .padding(all = 8.dp)
                 .fillMaxWidth()
         )

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/player/Player.kt
@@ -90,7 +90,7 @@ import app.vitune.compose.routing.OnGlobalRoute
 import app.vitune.core.ui.Dimensions
 import app.vitune.core.ui.LocalAppearance
 import app.vitune.core.ui.collapsedPlayerProgressBar
-import app.vitune.core.ui.enums.ThumbnailRoundness
+import app.vitune.core.ui.ThumbnailRoundness
 import app.vitune.core.ui.utils.isLandscape
 import app.vitune.core.ui.utils.px
 import app.vitune.core.ui.utils.roundedShape

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
@@ -3,6 +3,7 @@ package app.vitune.android.ui.screens.settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -18,10 +19,11 @@ import app.vitune.android.utils.currentLocale
 import app.vitune.android.utils.findActivity
 import app.vitune.android.utils.startLanguagePicker
 import app.vitune.core.ui.BuiltInFontFamily
+import app.vitune.core.ui.ColorMode
+import app.vitune.core.ui.ColorSource
+import app.vitune.core.ui.Darkness
 import app.vitune.core.ui.LocalAppearance
-import app.vitune.core.ui.enums.ColorPaletteMode
-import app.vitune.core.ui.enums.ColorPaletteName
-import app.vitune.core.ui.enums.ThumbnailRoundness
+import app.vitune.core.ui.ThumbnailRoundness
 import app.vitune.core.ui.googleFontsAvailable
 import app.vitune.core.ui.utils.isAtLeastAndroid13
 
@@ -30,24 +32,30 @@ import app.vitune.core.ui.utils.isAtLeastAndroid13
 fun AppearanceSettings() = with(AppearancePreferences) {
     val (colorPalette) = LocalAppearance.current
     val context = LocalContext.current
+    val isDark = isSystemInDarkTheme()
 
     SettingsCategoryScreen(title = stringResource(R.string.appearance)) {
         SettingsGroup(title = stringResource(R.string.colors)) {
             EnumValueSelectorSettingsEntry(
-                title = stringResource(R.string.theme),
-                selectedValue = colorPaletteName,
-                onValueSelected = { colorPaletteName = it },
+                title = stringResource(R.string.color_source),
+                selectedValue = colorSource,
+                onValueSelected = { colorSource = it },
                 valueText = { it.nameLocalized }
             )
-
             EnumValueSelectorSettingsEntry(
-                title = stringResource(R.string.theme_mode),
-                selectedValue = colorPaletteMode,
-                isEnabled = colorPaletteName != ColorPaletteName.PureBlack &&
-                        colorPaletteName != ColorPaletteName.AMOLED,
-                onValueSelected = { colorPaletteMode = it },
+                title = stringResource(R.string.color_mode),
+                selectedValue = colorMode,
+                onValueSelected = { colorMode = it },
                 valueText = { it.nameLocalized }
             )
+            AnimatedVisibility(visible = colorMode == ColorMode.Dark || (colorMode == ColorMode.System && isDark)) {
+                EnumValueSelectorSettingsEntry(
+                    title = stringResource(R.string.darkness),
+                    selectedValue = darkness,
+                    onValueSelected = { darkness = it },
+                    valueText = { it.nameLocalized }
+                )
+            }
         }
         SettingsGroup(title = stringResource(R.string.shapes)) {
             EnumValueSelectorSettingsEntry(
@@ -76,7 +84,7 @@ fun AppearanceSettings() = with(AppearancePreferences) {
             if (isAtLeastAndroid13) SettingsEntry(
                 title = stringResource(R.string.language),
                 text = currentLocale()?.displayLanguage
-                    ?: stringResource(R.string.theme_name_default),
+                    ?: stringResource(R.string.color_source_default),
                 onClick = {
                     context.findActivity().startLanguagePicker()
                 }
@@ -195,23 +203,30 @@ fun AppearanceSettings() = with(AppearancePreferences) {
     }
 }
 
-val ColorPaletteName.nameLocalized
+val ColorSource.nameLocalized
     @Composable get() = stringResource(
         when (this) {
-            ColorPaletteName.Default -> R.string.theme_name_default
-            ColorPaletteName.Dynamic -> R.string.theme_name_dynamic
-            ColorPaletteName.PureBlack -> R.string.theme_name_pureblack
-            ColorPaletteName.AMOLED -> R.string.theme_name_amoled
-            ColorPaletteName.MaterialYou -> R.string.theme_name_materialyou
+            ColorSource.Default -> R.string.color_source_default
+            ColorSource.Dynamic -> R.string.color_source_dynamic
+            ColorSource.MaterialYou -> R.string.color_source_material_you
         }
     )
 
-val ColorPaletteMode.nameLocalized
+val ColorMode.nameLocalized
     @Composable get() = stringResource(
         when (this) {
-            ColorPaletteMode.Light -> R.string.theme_mode_light
-            ColorPaletteMode.Dark -> R.string.theme_mode_dark
-            ColorPaletteMode.System -> R.string.theme_mode_system
+            ColorMode.System -> R.string.color_mode_system
+            ColorMode.Light -> R.string.color_mode_light
+            ColorMode.Dark -> R.string.color_mode_dark
+        }
+    )
+
+val Darkness.nameLocalized
+    @Composable get() = stringResource(
+        when (this) {
+            Darkness.Normal -> R.string.darkness_normal
+            Darkness.AMOLED -> R.string.darkness_amoled
+            Darkness.PureBlack -> R.string.darkness_pureblack
         }
     )
 

--- a/app/src/main/kotlin/app/vitune/android/utils/MonetCompat.kt
+++ b/app/src/main/kotlin/app/vitune/android/utils/MonetCompat.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import app.vitune.core.ui.ColorPalette
-import app.vitune.core.ui.DefaultLightColorPalette
+import app.vitune.core.ui.defaultLightPalette
 import com.kieronquinn.monetcompat.core.MonetCompat
 import kotlinx.coroutines.launch
 
@@ -24,7 +24,7 @@ inline fun MonetCompat.invokeOnReady(
     }
 }
 
-fun MonetCompat.setDefaultPalette(palette: ColorPalette = DefaultLightColorPalette) {
+fun MonetCompat.setDefaultPalette(palette: ColorPalette = defaultLightPalette) {
     defaultAccentColor = palette.accent.toArgb()
     defaultBackgroundColor = palette.background0.toArgb()
     defaultPrimaryColor = palette.background1.toArgb()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -184,17 +184,20 @@
     <string name="request_feature">Eine Funktion anfordern oder eine Idee vorschlagen</string>
     <string name="request_feature_description">Sie werden zu GitHub weitergeleitet</string>
 
-    <string name="theme">Thema</string>
-    <string name="theme_name_default">Standard</string>
-    <string name="theme_name_dynamic">Dynamisch</string>
-    <string name="theme_name_pureblack">Rein Schwarz</string>
-    <string name="theme_name_amoled">AMOLED</string>
-    <string name="theme_name_materialyou">Material You</string>
+    <string name="color_source">Akzent Farbquelle</string>
+    <string name="color_source_default">Standard</string>
+    <string name="color_source_dynamic">Dynamisch</string>
+    <string name="color_source_material_you">Material You</string>
 
-    <string name="theme_mode">Theme-Modus</string>
-    <string name="theme_mode_light">Hell</string>
-    <string name="theme_mode_dark">Dunkel</string>
-    <string name="theme_mode_system">System</string>
+    <string name="darkness">Dunkelheit</string>
+    <string name="darkness_normal">Normal</string>
+    <string name="darkness_pureblack">Rein Schwarz</string>
+    <string name="darkness_amoled">AMOLED</string>
+
+    <string name="color_mode">Theme-Modus</string>
+    <string name="color_mode_light">Hell</string>
+    <string name="color_mode_dark">Dunkel</string>
+    <string name="color_mode_system">System</string>
 
     <string name="thumbnail_roundness">Rundheit der Vorschaubilder</string>
     <string name="thumbnail_roundness_none">Keine</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -182,17 +182,20 @@
     <string name="request_feature">Minta fitur atau usulkan ide</string>
     <string name="request_feature_description">Anda akan diarahkan ke GitHub</string>
 
-    <string name="theme">Tema</string>
-    <string name="theme_name_default">Default</string>
-    <string name="theme_name_dynamic">Dinamis</string>
-    <string name="theme_name_pureblack">Hitam Murni</string>
-    <string name="theme_name_amoled">AMOLED</string>
-    <string name="theme_name_materialyou">Material You</string>
+    <string name="color_source">Sumber warna aksen</string>
+    <string name="color_source_default">Default</string>
+    <string name="color_source_dynamic">Dinamis</string>
+    <string name="color_source_material_you">Material You</string>
 
-    <string name="theme_mode">Mode tema</string>
-    <string name="theme_mode_light">Terang</string>
-    <string name="theme_mode_dark">Gelap</string>
-    <string name="theme_mode_system">Sistem</string>
+    <string name="darkness">Kegelapan</string>
+    <string name="darkness_normal">Normal</string>
+    <string name="darkness_pureblack">Hitam Murni</string>
+    <string name="darkness_amoled">AMOLED</string>
+
+    <string name="color_mode">Mode</string>
+    <string name="color_mode_light">Terang</string>
+    <string name="color_mode_dark">Gelap</string>
+    <string name="color_mode_system">Sistem</string>
 
     <string name="thumbnail_roundness">Kebulatan thumbnail</string>
     <string name="thumbnail_roundness_none">Tidak ada</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -184,17 +184,20 @@
     <string name="request_feature">Verzoek een functie of suggereer een idee</string>
     <string name="request_feature_description">Je wordt doorverwezen naar GitHub</string>
 
-    <string name="theme">Thema</string>
-    <string name="theme_name_default">Standaard</string>
-    <string name="theme_name_dynamic">Dynamisch</string>
-    <string name="theme_name_pureblack">PuurZwart</string>
-    <string name="theme_name_amoled">AMOLED</string>
-    <string name="theme_name_materialyou">Material You</string>
+    <string name="color_source">Bron voor accentkleur</string>
+    <string name="color_source_default">Standaard</string>
+    <string name="color_source_dynamic">Dynamisch</string>
+    <string name="color_source_material_you">Material You</string>
 
-    <string name="theme_mode">Modus</string>
-    <string name="theme_mode_light">Licht</string>
-    <string name="theme_mode_dark">Donker</string>
-    <string name="theme_mode_system">Systeem</string>
+    <string name="darkness">Donkerheid</string>
+    <string name="darkness_normal">Normaal</string>
+    <string name="darkness_pureblack">PuurZwart</string>
+    <string name="darkness_amoled">AMOLED</string>
+
+    <string name="color_mode">Modus</string>
+    <string name="color_mode_light">Licht</string>
+    <string name="color_mode_dark">Donker</string>
+    <string name="color_mode_system">Systeem</string>
 
     <string name="thumbnail_roundness">Rondheid van miniaturen</string>
     <string name="thumbnail_roundness_none">Geen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,17 +184,20 @@
     <string name="request_feature">Request a feature or suggest an idea</string>
     <string name="request_feature_description">You will be redirected to GitHub</string>
 
-    <string name="theme">Theme</string>
-    <string name="theme_name_default">Default</string>
-    <string name="theme_name_dynamic">Dynamic</string>
-    <string name="theme_name_pureblack">PureBlack</string>
-    <string name="theme_name_amoled">AMOLED</string>
-    <string name="theme_name_materialyou">Material You</string>
+    <string name="color_source">Accent color source</string>
+    <string name="color_source_default">Default</string>
+    <string name="color_source_dynamic">Dynamic</string>
+    <string name="color_source_material_you">Material You</string>
 
-    <string name="theme_mode">Theme mode</string>
-    <string name="theme_mode_light">Light</string>
-    <string name="theme_mode_dark">Dark</string>
-    <string name="theme_mode_system">System</string>
+    <string name="darkness">Darkness</string>
+    <string name="darkness_normal">Normal</string>
+    <string name="darkness_pureblack">PureBlack</string>
+    <string name="darkness_amoled">AMOLED</string>
+
+    <string name="color_mode">Mode</string>
+    <string name="color_mode_light">Light</string>
+    <string name="color_mode_dark">Dark</string>
+    <string name="color_mode_system">System</string>
 
     <string name="thumbnail_roundness">Thumbnail roundness</string>
     <string name="thumbnail_roundness_none">None</string>

--- a/compose/preferences/src/main/kotlin/app/vitune/compose/preferences/PreferencesHolders.kt
+++ b/compose/preferences/src/main/kotlin/app/vitune/compose/preferences/PreferencesHolders.kt
@@ -76,49 +76,77 @@ open class PreferencesHolder(
     name: String,
     mode: Int = Context.MODE_PRIVATE
 ) : SharedPreferences by application.getSharedPreferences(name, mode) {
-    fun boolean(defaultValue: Boolean) = SharedPreferencesProperty(
+    fun boolean(
+        defaultValue: Boolean,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getBoolean(it, defaultValue) },
         set = { k, v -> putBoolean(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    fun string(defaultValue: String) = SharedPreferencesProperty(
+    fun string(
+        defaultValue: String,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getString(it, null) ?: defaultValue },
         set = { k, v -> putString(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    fun int(defaultValue: Int) = SharedPreferencesProperty(
+    fun int(
+        defaultValue: Int,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getInt(it, defaultValue) },
         set = { k, v -> putInt(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    fun float(defaultValue: Float) = SharedPreferencesProperty(
+    fun float(
+        defaultValue: Float,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getFloat(it, defaultValue) },
         set = { k, v -> putFloat(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    fun long(defaultValue: Long) = SharedPreferencesProperty(
+    fun long(
+        defaultValue: Long,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getLong(it, defaultValue) },
         set = { k, v -> putLong(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    inline fun <reified T : Enum<T>> enum(defaultValue: T) = SharedPreferencesProperty(
+    inline fun <reified T : Enum<T>> enum(
+        defaultValue: T,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = {
             getString(it, null)
                 ?.let { runCatching { enumValueOf<T>(it) }.getOrNull() }
                 ?: defaultValue
         },
         set = { k, v -> putString(k, v.name) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 
-    fun stringSet(defaultValue: Set<String>) = SharedPreferencesProperty(
+    fun stringSet(
+        defaultValue: Set<String>,
+        name: String? = null
+    ) = SharedPreferencesProperty(
         get = { getStringSet(it, null) ?: defaultValue },
         set = { k, v -> putStringSet(k, v) },
-        default = defaultValue
+        default = defaultValue,
+        name = name
     )
 }

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/Enums.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/Enums.kt
@@ -1,4 +1,4 @@
-package app.vitune.core.ui.enums
+package app.vitune.core.ui
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -13,4 +13,22 @@ enum class ThumbnailRoundness(val dp: Dp) {
     Heaviest(18.dp);
 
     val shape get() = dp.roundedShape
+}
+
+enum class ColorSource {
+    Default,
+    Dynamic,
+    MaterialYou
+}
+
+enum class ColorMode {
+    System,
+    Light,
+    Dark
+}
+
+enum class Darkness {
+    Normal,
+    AMOLED,
+    PureBlack
 }

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteMode.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteMode.kt
@@ -1,7 +1,0 @@
-package app.vitune.core.ui.enums
-
-enum class ColorPaletteMode {
-    Light,
-    Dark,
-    System
-}

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/enums/ColorPaletteName.kt
@@ -1,9 +1,0 @@
-package app.vitune.core.ui.enums
-
-enum class ColorPaletteName(val isDynamic: Boolean) {
-    Default(isDynamic = false),
-    Dynamic(isDynamic = true),
-    MaterialYou(isDynamic = true),
-    PureBlack(isDynamic = false),
-    AMOLED(isDynamic = true)
-}

--- a/core/ui/src/main/kotlin/app/vitune/core/ui/utils/Saver.kt
+++ b/core/ui/src/main/kotlin/app/vitune/core/ui/utils/Saver.kt
@@ -2,8 +2,6 @@ package app.vitune.core.ui.utils
 
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.flow.MutableStateFlow
 
 fun <Type : Any> stateFlowSaver() = stateFlowSaverOf<Type, Type>(
@@ -17,9 +15,4 @@ inline fun <Type, Saveable : Any> stateFlowSaverOf(
 ) = object : Saver<MutableStateFlow<Type>, Saveable> {
     override fun restore(value: Saveable) = MutableStateFlow(from(value))
     override fun SaverScope.save(value: MutableStateFlow<Type>) = to(value.value)
-}
-
-val Color.Companion.Saver get() = object : Saver<Color, Int> {
-    override fun restore(value: Int) = Color(value)
-    override fun SaverScope.save(value: Color) = value.toArgb()
 }


### PR DESCRIPTION
## Rewrite color palette logic

Color palettes are now generated from three new factors: color source, color mode and darkness.

Color sources:

- Default
- Dynamic
- Material You

Color modes:

- "Let the system choose"
- Light
- Dark

Darkness (only applicable to dark mode):

- Normal
- AMOLED
- PureBlack

This way, the theming of ViTune will be even more customizable, because there are more possible
color palette combinations than before.
Old color preferences are being migrated automatically to the new primitives, so there are basically
no breaking changes for the end user.

Resolves: #142
See: #142, #214