### PR TITLE
Add Retrospective

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/preferences/DataPreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/DataPreferences.kt
@@ -26,6 +26,7 @@ object DataPreferences : GlobalPreferencesHolder() {
     var shouldCacheQuickPicks by boolean(true)
     var cachedQuickPicks by json(Innertube.RelatedPage())
     var autoSyncPlaylists by boolean(true)
+    var showRetrospectiveAllYear by boolean(false)
 
     enum class TopListPeriod(
         val displayName: @Composable () -> String,

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeDiscovery.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeDiscovery.kt
@@ -79,7 +79,9 @@ import app.vitune.core.ui.utils.isLandscape
 import app.vitune.providers.innertube.Innertube
 import app.vitune.providers.innertube.models.NavigationEndpoint
 import app.vitune.providers.innertube.requests.discoverPage
-import java.util.Calendar
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 // TODO: a lot of duplicate code all around the codebase, especially for discover
 
@@ -112,7 +114,7 @@ fun HomeDiscovery(
         .padding(top = 24.dp, bottom = 8.dp)
         .padding(endPaddingValues)
 
-    val isDecember = Calendar.getInstance().get(Calendar.MONTH) == 4
+    val isDecember = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).month.value == 12;
     val showRetrospective = isDecember || DataPreferences.showRetrospectiveAllYear
 
     var discoverPage by persist<Result<Innertube.DiscoverPage>>("home/discovery")
@@ -151,7 +153,7 @@ fun HomeDiscovery(
             discoverPage?.getOrNull()?.let { page ->
                 if(showRetrospective){
                     RetrospectiveButton(
-                        title = "${Calendar.getInstance().get(Calendar.YEAR)} ${stringResource(R.string.retrospective)}",
+                        title = "${Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year} ${stringResource(R.string.retrospective)}",
                         onClick = { onRetrospectiveClick() },
                         modifier = Modifier
                             .width(fullWidth)

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeDiscovery.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeDiscovery.kt
@@ -2,6 +2,7 @@ package app.vitune.android.ui.screens.home
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -29,6 +30,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.runtime.Composable
@@ -39,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.res.stringResource
@@ -48,6 +51,7 @@ import androidx.compose.ui.unit.times
 import app.vitune.android.LocalPlayerAwareWindowInsets
 import app.vitune.android.LocalPlayerServiceBinder
 import app.vitune.android.R
+import app.vitune.android.preferences.DataPreferences
 import app.vitune.android.ui.components.FadingRow
 import app.vitune.android.ui.components.LocalMenuState
 import app.vitune.android.ui.components.ShimmerHost
@@ -75,6 +79,7 @@ import app.vitune.core.ui.utils.isLandscape
 import app.vitune.providers.innertube.Innertube
 import app.vitune.providers.innertube.models.NavigationEndpoint
 import app.vitune.providers.innertube.requests.discoverPage
+import java.util.Calendar
 
 // TODO: a lot of duplicate code all around the codebase, especially for discover
 
@@ -87,6 +92,7 @@ fun HomeDiscovery(
     onSearchClick: () -> Unit,
     onMoreMoodsClick: () -> Unit,
     onMoreAlbumsClick: () -> Unit,
+    onRetrospectiveClick: () -> Unit,
     onPlaylistClick: (browseId: String) -> Unit
 ) {
     val (colorPalette, typography) = LocalAppearance.current
@@ -106,6 +112,9 @@ fun HomeDiscovery(
         .padding(top = 24.dp, bottom = 8.dp)
         .padding(endPaddingValues)
 
+    val isDecember = Calendar.getInstance().get(Calendar.MONTH) == 4
+    val showRetrospective = isDecember || DataPreferences.showRetrospectiveAllYear
+
     var discoverPage by persist<Result<Innertube.DiscoverPage>>("home/discovery")
 
     LaunchedEffect(Unit) {
@@ -121,6 +130,7 @@ fun HomeDiscovery(
             }
         )
         val itemWidth = maxWidth * widthFactor
+        val fullWidth = maxWidth
 
         Column(
             modifier = Modifier
@@ -139,6 +149,16 @@ fun HomeDiscovery(
             )
 
             discoverPage?.getOrNull()?.let { page ->
+                if(showRetrospective){
+                    RetrospectiveButton(
+                        title = "${Calendar.getInstance().get(Calendar.YEAR)} ${stringResource(R.string.retrospective)}",
+                        onClick = { onRetrospectiveClick() },
+                        modifier = Modifier
+                            .width(fullWidth)
+                            .padding(4.dp)
+                    )
+                }
+
                 if (page.moods.isNotEmpty()) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -348,6 +368,55 @@ fun HomeDiscovery(
             icon = R.drawable.search,
             onClick = onSearchClick
         )
+    }
+}
+
+@Composable
+fun RetrospectiveButton(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val typography = LocalAppearance.current.typography
+    val thumbnailShape = LocalAppearance.current.thumbnailShape
+
+    val color by remember { derivedStateOf { Color.Transparent } }
+
+    val rainbowBrush = remember {
+        Brush.linearGradient(
+            colors = listOf(
+                Color(0xFFFF0000),
+                Color(0xFFFF8700),
+                Color(0xFFFFD300),
+                Color(0xFFDEFF0A),
+                Color(0xFFA1FF0A),
+                Color(0xFF0AFF99),
+                Color(0xFF0AEFFF),
+                Color(0xFF147DF5),
+                Color(0xFF580AFF),
+                Color(0xFFBE0AFF)
+            )
+        )
+    }
+
+    Card(
+        modifier = modifier
+            .height(Dimensions.items.moodHeight)
+            .border(1.dp, rainbowBrush, thumbnailShape),
+        shape = thumbnailShape,
+        colors = CardDefaults.elevatedCardColors(containerColor = color)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable { onClick() },
+            contentAlignment = Alignment.Center
+        ) {
+            BasicText(
+                text = title,
+                style = typography.xs.semiBold
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import app.vitune.android.ui.screens.localplaylist.LocalPlaylistScreen
 import app.vitune.android.ui.screens.mood.MoodScreen
 import app.vitune.android.ui.screens.mood.MoreAlbumsScreen
 import app.vitune.android.ui.screens.mood.MoreMoodsScreen
+import app.vitune.android.ui.screens.mood.RetrospectiveScreen
 import app.vitune.android.ui.screens.moodRoute
 import app.vitune.android.ui.screens.pipedPlaylistRoute
 import app.vitune.android.ui.screens.playlistRoute
@@ -28,6 +29,7 @@ import app.vitune.compose.routing.RouteHandler
 
 private val moreMoodsRoute = Route0("moreMoodsRoute")
 private val moreAlbumsRoute = Route0("moreAlbumsRoute")
+private val retrospectiveRoute = Route0("retrospectiveRoute")
 
 @Route
 @Composable
@@ -57,6 +59,10 @@ fun HomeScreen() {
 
         moreAlbumsRoute {
             MoreAlbumsScreen()
+        }
+
+        retrospectiveRoute {
+            RetrospectiveScreen()
         }
 
         Content {
@@ -99,6 +105,7 @@ fun HomeScreen() {
                             onSearchClick = onSearchClick,
                             onMoreMoodsClick = { moreMoodsRoute() },
                             onMoreAlbumsClick = { moreAlbumsRoute() },
+                            onRetrospectiveClick = { retrospectiveRoute() },
                             onPlaylistClick = { playlistRoute(it, null, null, true) }
                         )
 

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/mood/RetrospectiveScreen.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/mood/RetrospectiveScreen.kt
@@ -1,0 +1,47 @@
+package app.vitune.android.ui.screens.mood
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import app.vitune.android.R
+import app.vitune.android.ui.components.themed.Scaffold
+import app.vitune.android.ui.screens.GlobalRoutes
+import app.vitune.android.ui.screens.Route
+import app.vitune.compose.persist.PersistMapCleanup
+import app.vitune.compose.routing.RouteHandler
+
+@Route
+@Composable
+fun RetrospectiveScreen() {
+    val saveableStateHolder = rememberSaveableStateHolder()
+
+    PersistMapCleanup(prefix = "retrospective")
+
+    RouteHandler {
+        GlobalRoutes()
+
+        Content {
+            Scaffold(
+                key = "retrospective",
+                topIconButtonId = R.drawable.chevron_back,
+                onTopIconButtonClick = pop,
+                tabIndex = 0,
+                onTabChange = { },
+                tabColumnContent = {
+                    tab(0, R.string.retrospective, R.drawable.disc)
+                    /*
+                        - Top listened artists
+                        - Top listened songs
+                        - Top genders
+                        - Total minutes listened
+                     */
+                }
+            ) { currentTabIndex ->
+                saveableStateHolder.SaveableStateProvider(key = currentTabIndex) {
+                    when (currentTabIndex) {
+                        0 -> null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/settings/OtherSettings.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/settings/OtherSettings.kt
@@ -175,6 +175,14 @@ fun OtherSettings() {
                 onCheckedChange = { DataPreferences.shouldCacheQuickPicks = it }
             )
         }
+        SettingsGroup(title = stringResource(R.string.retrospective)) {
+            SwitchSettingsEntry(
+                title = stringResource(R.string.enable_retrospective_all_time),
+                text = stringResource(R.string.enable_retrospective_all_time_description),
+                isChecked = DataPreferences.showRetrospectiveAllYear,
+                onCheckedChange = { DataPreferences.showRetrospectiveAllYear = it }
+            )
+        }
         SettingsGroup(title = stringResource(R.string.dynamic_thumbnails)) {
             var selectingThumbnailSize by remember { mutableStateOf(false) }
             SettingsEntry(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,6 +416,10 @@
 
     <string name="tabs">Tabs</string>
 
+    <string name="retrospective">Retrospective</string>
+    <string name="enable_retrospective_all_time">Enable retrospective all year</string>
+    <string name="enable_retrospective_all_time_description">Shows the retrospective throughout the whole year</string>
+
     <plurals name="format_reset_blacklist_description">
         <item quantity="one">Remove %1$s song from the blacklist</item>
         <item quantity="other">Remove all %1$s songs from the blacklist</item>


### PR DESCRIPTION
## **Add a retrospective (like a Spotify Wrapped) feature to the discover page #615**

### Button to acess the retrospective
<img src="https://github.com/user-attachments/assets/29a0ff04-414d-470f-9693-c611025056ab" width="250">

The button only appears in december or when the setting *showRetrospectiveAllYear* is *on*

### Setting to show the retrospective btn all year (showRetrospectiveAllYear)
<img src="https://github.com/user-attachments/assets/2ee4c4c4-afcd-45dd-b166-399d79856616" width="250">

### Retrospective Share screen
_TODO_
This page will be like the final page of spotify wrapped, with:
- Top 5 artists
- Top 5 songs
- Top gender
- Total minutes listened

### Retrospective Top listened artists screen
_TODO_

### Retrospective Top listened songs screen
_TODO_

### Retrospective Top listened genders screen
_TODO_