### PR TITLE
workaround for yt-dlp

### DIFF
--- a/app/src/main/python/download.py
+++ b/app/src/main/python/download.py
@@ -4,7 +4,12 @@ import json
 
 def download(video_id):
     opts = {
-        'format': 'bestaudio'
+        'format': 'bestaudio',
+        'extractor_args': {
+            'youtube': {
+                'player-client':['default', 'tv_simply']
+            }
+        }
     }
 
     return json.dumps(yt_dlp.YoutubeDL(opts).extract_info(video_id, download=False), indent=4)


### PR DESCRIPTION
Temporary workaround for yt-dlp's PO requirements.

Seems youtube wants po tokens for somecases and ip banning people for api rate limit exceed. [yt-dlp #11868](https://github.com/yt-dlp/yt-dlp/issues/11868)
I switched the player client to tv_simply to avoid the po token/rate limit for now.

Replaceable with suitable po providers or something.
