### PR TITLE
feat(ui): configurable navigation rail position (left/right)

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
+++ b/app/src/main/kotlin/app/vitune/android/preferences/AppearancePreferences.kt
@@ -3,6 +3,7 @@ package app.vitune.android.preferences
 import app.vitune.android.GlobalPreferencesHolder
 import app.vitune.android.preferences.OldPreferences.ColorPaletteMode
 import app.vitune.android.preferences.OldPreferences.ColorPaletteName
+import app.vitune.core.data.enums.NavigationRailPosition
 import app.vitune.core.ui.BuiltInFontFamily
 import app.vitune.core.ui.ColorMode
 import app.vitune.core.ui.ColorSource
@@ -32,6 +33,7 @@ object AppearancePreferences : GlobalPreferencesHolder() {
         }
     )
     var thumbnailRoundness by enum(ThumbnailRoundness.Medium)
+    var navigationRailPosition by enum(NavigationRailPosition.Left)
     var fontFamily by enum(BuiltInFontFamily.Poppins)
     var applyFontPadding by boolean(false)
     val isShowingThumbnailInLockscreenProperty = boolean(true)

--- a/app/src/main/kotlin/app/vitune/android/ui/components/themed/NavigationRail.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/components/themed/NavigationRail.kt
@@ -56,6 +56,7 @@ import app.vitune.android.ui.screens.settings.SwitchSettingsEntry
 import app.vitune.android.utils.center
 import app.vitune.android.utils.color
 import app.vitune.android.utils.semiBold
+import app.vitune.core.data.enums.NavigationRailPosition
 import app.vitune.core.ui.Dimensions
 import app.vitune.core.ui.LocalAppearance
 import app.vitune.core.ui.utils.isLandscape
@@ -189,6 +190,7 @@ inline fun NavigationRail(
     crossinline setHiddenTabs: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
     tabsEditingTitle: String = stringResource(R.string.tabs),
+    position: NavigationRailPosition = NavigationRailPosition.Left,
     crossinline content: TabsBuilder.() -> Unit
 ) {
     val (colorPalette, typography) = LocalAppearance.current
@@ -196,8 +198,15 @@ inline fun NavigationRail(
     val tabs = TabsBuilder.rememberTabs(content)
     val isLandscape = isLandscape
 
+    // Apply the inset on whichever side the rail is docked against, so it never collides with the
+    // system bars / display cutout when moved to the right.
+    val horizontalInsetSide = when (position) {
+        NavigationRailPosition.Left -> WindowInsetsSides.Start
+        NavigationRailPosition.Right -> WindowInsetsSides.End
+    }
+
     val paddingValues = LocalPlayerAwareWindowInsets.current
-        .only(WindowInsetsSides.Vertical + WindowInsetsSides.Start)
+        .only(WindowInsetsSides.Vertical + horizontalInsetSide)
         .asPaddingValues()
 
     var editing by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/app/vitune/android/ui/components/themed/NavigationRail.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/components/themed/NavigationRail.kt
@@ -199,10 +199,11 @@ inline fun NavigationRail(
     val isLandscape = isLandscape
 
     // Apply the inset on whichever side the rail is docked against, so it never collides with the
-    // system bars / display cutout when moved to the right.
+    // system bars / display cutout when moved to the right. Absolute Left/Right sides are used
+    // (rather than Start/End) so the physical edge is correct regardless of layout direction.
     val horizontalInsetSide = when (position) {
-        NavigationRailPosition.Left -> WindowInsetsSides.Start
-        NavigationRailPosition.Right -> WindowInsetsSides.End
+        NavigationRailPosition.Left -> WindowInsetsSides.Left
+        NavigationRailPosition.Right -> WindowInsetsSides.Right
     }
 
     val paddingValues = LocalPlayerAwareWindowInsets.current

--- a/app/src/main/kotlin/app/vitune/android/ui/components/themed/Scaffold.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/components/themed/Scaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,7 +19,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import app.vitune.android.R
+import app.vitune.android.preferences.AppearancePreferences
 import app.vitune.android.preferences.UIStatePreferences
+import app.vitune.core.data.enums.NavigationRailPosition
 import app.vitune.core.ui.LocalAppearance
 import kotlinx.collections.immutable.toImmutableList
 
@@ -37,11 +40,9 @@ fun Scaffold(
     val (colorPalette) = LocalAppearance.current
     var hiddenTabs by UIStatePreferences.mutableTabStateOf(key)
 
-    Row(
-        modifier = modifier
-            .background(colorPalette.background0)
-            .fillMaxSize()
-    ) {
+    val navigationRailPosition = AppearancePreferences.navigationRailPosition
+
+    val navigationRail: @Composable () -> Unit = {
         NavigationRail(
             topIconButtonId = topIconButtonId,
             onTopIconButtonClick = onTopIconButtonClick,
@@ -50,11 +51,15 @@ fun Scaffold(
             hiddenTabs = hiddenTabs,
             setHiddenTabs = { hiddenTabs = it.toImmutableList() },
             tabsEditingTitle = tabsEditingTitle,
+            position = navigationRailPosition,
             content = tabColumnContent
         )
+    }
 
+    val mainContent: @Composable (Modifier) -> Unit = { contentModifier ->
         AnimatedContent(
             targetState = tabIndex,
+            modifier = contentModifier,
             transitionSpec = {
                 val slideDirection = if (targetState > initialState) Up else Down
                 val animationSpec = spring(
@@ -72,5 +77,23 @@ fun Scaffold(
             content = content,
             label = ""
         )
+    }
+
+    Row(
+        modifier = modifier
+            .background(colorPalette.background0)
+            .fillMaxSize()
+    ) {
+        // The rail keeps its intrinsic width; the main content takes the remaining space via
+        // weight. Without the weight the content's fillMaxSize would consume the whole row and
+        // push the rail off-screen when it's ordered first (i.e. docked on the right).
+        // The navigation rail sits on the side selected in appearance settings.
+        if (navigationRailPosition == NavigationRailPosition.Right) {
+            mainContent(Modifier.weight(1f).fillMaxHeight())
+            navigationRail()
+        } else {
+            navigationRail()
+            mainContent(Modifier.weight(1f).fillMaxHeight())
+        }
     }
 }

--- a/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/app/vitune/android/ui/screens/settings/AppearanceSettings.kt
@@ -18,6 +18,7 @@ import app.vitune.android.ui.screens.Route
 import app.vitune.android.utils.currentLocale
 import app.vitune.android.utils.findActivity
 import app.vitune.android.utils.startLanguagePicker
+import app.vitune.core.data.enums.NavigationRailPosition
 import app.vitune.core.ui.BuiltInFontFamily
 import app.vitune.core.ui.ColorMode
 import app.vitune.core.ui.ColorSource
@@ -77,6 +78,14 @@ fun AppearanceSettings() = with(AppearancePreferences) {
                             .size(36.dp)
                     )
                 },
+                valueText = { it.nameLocalized }
+            )
+        }
+        SettingsGroup(title = stringResource(R.string.layout)) {
+            EnumValueSelectorSettingsEntry(
+                title = stringResource(R.string.navigation_rail_position),
+                selectedValue = navigationRailPosition,
+                onValueSelect = { navigationRailPosition = it },
                 valueText = { it.nameLocalized }
             )
         }
@@ -273,5 +282,13 @@ val ThumbnailRoundness.nameLocalized
             ThumbnailRoundness.Heavy -> R.string.thumbnail_roundness_heavy
             ThumbnailRoundness.Heavier -> R.string.thumbnail_roundness_heavier
             ThumbnailRoundness.Heaviest -> R.string.thumbnail_roundness_heaviest
+        }
+    )
+
+val NavigationRailPosition.nameLocalized
+    @Composable get() = stringResource(
+        when (this) {
+            NavigationRailPosition.Left -> R.string.navigation_rail_position_left
+            NavigationRailPosition.Right -> R.string.navigation_rail_position_right
         }
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="appearance">Appearance</string>
     <string name="colors">Colors</string>
     <string name="shapes">Shapes</string>
+    <string name="layout">Layout</string>
     <string name="skip_back">Skip back</string>
     <string name="skip_forward">Skip forward</string>
     <string name="play">Play</string>
@@ -181,6 +182,9 @@
     <string name="thumbnail_roundness_heavy">Heavy</string>
     <string name="thumbnail_roundness_heavier">Even heavier</string>
     <string name="thumbnail_roundness_heaviest">Heaviest</string>
+    <string name="navigation_rail_position">Navigation bar position</string>
+    <string name="navigation_rail_position_left">Left</string>
+    <string name="navigation_rail_position_right">Right</string>
     <string name="text">Text</string>
     <string name="font">Font</string>
     <string name="use_system_font">Use system font</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@
     <string name="thumbnail_roundness_heavy">Heavy</string>
     <string name="thumbnail_roundness_heavier">Even heavier</string>
     <string name="thumbnail_roundness_heaviest">Heaviest</string>
-    <string name="navigation_rail_position">Navigation bar position</string>
+    <string name="navigation_rail_position">Navigation rail position</string>
     <string name="navigation_rail_position_left">Left</string>
     <string name="navigation_rail_position_right">Right</string>
     <string name="text">Text</string>

--- a/core/data/src/main/kotlin/app/vitune/core/data/enums/NavigationRailPosition.kt
+++ b/core/data/src/main/kotlin/app/vitune/core/data/enums/NavigationRailPosition.kt
@@ -1,0 +1,6 @@
+package app.vitune.core.data.enums
+
+enum class NavigationRailPosition {
+    Left,
+    Right
+}


### PR DESCRIPTION
## What

Adds an appearance setting to choose which side the navigation rail is docked on: **Left** (default, unchanged behaviour) or **Right**.

Found under **Settings → Appearance → Layout → Navigation bar position**.

## Why

On larger phones and tablets, a right-side navigation rail is much easier to reach one-handed for right-handed users. It's a small, opt-in personalization with zero impact on existing users (defaults to `Left`).

## How

- New `NavigationRailPosition` enum in `core:data`.
- New `AppearancePreferences.navigationRailPosition` preference, defaulting to `Left`.
- `Scaffold` orders the rail and content according to the preference. The main content now uses `Modifier.weight(1f)` so the fixed-width rail always keeps its slot regardless of child order — without this, the content's `fillMaxSize` consumed the whole row and pushed the rail off-screen when it was ordered first (right side).
- `NavigationRail` applies the horizontal window inset (`WindowInsetsSides.Start`/`End`) on whichever edge it is docked against, so it respects system bars / display cutouts on the right.
- Settings entry added under a new **Layout** group in Appearance settings, reusing the existing `EnumValueSelectorSettingsEntry`.

Because every screen renders through the shared `Scaffold`, the setting applies everywhere (Home, Search, Album, Artist, Settings, …) in both portrait and landscape.

## Testing

Verified on an Android emulator:

| Scenario | Result |
| --- | --- |
| Portrait · Left (default) | Rail on left, identical to current behaviour |
| Portrait · Right | Rail docked on right, content fills the left |
| Landscape · Right | Rail docked on right |
| Switch Right → Left | Reverts cleanly |
| Non-Home screens (Settings, etc.) | Respect the setting |

`./gradlew :app:assembleDebug` passes. `./gradlew :app:detekt` reports no new issues in any changed file (the two pre-existing `ImportOrdering` warnings in `About.kt` / `PlayerState.kt` are untouched by this PR).

## Notes

- Only the default English strings are added (`navigation_rail_position`, `…_left`, `…_right`, `layout`); translations can follow via the usual localization flow.
- No database migration, no new dependencies.