### PR TITLE
fix: resolve playback errors by using Innertube URLs directly with yt…

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/service/PlayerService.kt
+++ b/app/src/main/kotlin/app/vitune/android/service/PlayerService.kt
@@ -1421,16 +1421,30 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
                     }?.getOrNull()
                     val youtubeFormat = body?.streamingData?.highestQualityFormat
 
-                    val info = runCatching {
-                        Dependencies.runDownload(mediaId)
-                    }.mapCatching {
-                        YouTubeDLResponse.fromString(it)
-                    }.also { it.exceptionOrNull()?.printStackTrace() }.getOrNull()
-                    if (info?.id != mediaId) throw VideoIdMismatchException()
-                    val format = info.formats?.firstOrNull { it.formatId == info.formatId }
+                    var uri: Uri? = runCatching { youtubeFormat?.url?.toUri() }.getOrNull()
+                    var formatItag: Int? = youtubeFormat?.itag
+                    var formatMimeType: String? = youtubeFormat?.mimeType
+                    var formatBitrate: Long? = youtubeFormat?.bitrate
+                    var formatContentLength: Long? = youtubeFormat?.contentLength
 
-                    val uri =
-                        runCatching { info.url?.toUri() }.getOrNull() ?: throw UnplayableException()
+                    if (uri == null) {
+                        val info = runCatching {
+                            Dependencies.runDownload(mediaId)
+                        }.mapCatching {
+                            YouTubeDLResponse.fromString(it)
+                        }.also { it.exceptionOrNull()?.printStackTrace() }.getOrNull()
+
+                        if (info != null) {
+                            if (info.id != mediaId) throw VideoIdMismatchException()
+                            uri = runCatching { info.url?.toUri() }.getOrNull()
+                            val format = info.formats?.firstOrNull { it.formatId == info.formatId }
+                            formatItag = formatItag ?: info.formatId?.toIntOrNull()
+                            formatBitrate = formatBitrate ?: format?.abr?.let { (it * 1000).toLong() }
+                            formatContentLength = formatContentLength ?: info.fileSize
+                        }
+                    }
+
+                    val finalUri = uri ?: throw UnplayableException()
 
                     val mediaItem = runCatching {
                         runBlocking(Dispatchers.IO) { findMediaItem(mediaId) }
@@ -1457,11 +1471,11 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
                             Database.insert(
                                 Format(
                                     songId = mediaId,
-                                    itag = info.formatId?.toIntOrNull(),
-                                    mimeType = youtubeFormat?.mimeType,
-                                    bitrate = format?.abr?.let { it * 1000 }?.toLong(),
+                                    itag = formatItag,
+                                    mimeType = formatMimeType,
+                                    bitrate = formatBitrate,
                                     loudnessDb = body?.playerConfig?.audioConfig?.normalizedLoudnessDb,
-                                    contentLength = info.fileSize,
+                                    contentLength = formatContentLength,
                                     lastModified = youtubeFormat?.lastModified
                                 )
                             )
@@ -1470,13 +1484,13 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
 
                     uriCache.push(
                         key = mediaId,
-                        meta = info.fileSize,
-                        uri = uri
+                        meta = formatContentLength,
+                        uri = finalUri
                     )
 
                     dataSpec
-                        .withUri(uri)
-                        .ranged(info.fileSize)
+                        .withUri(finalUri)
+                        .ranged(formatContentLength)
                 }
             }
         }.handleUnknownErrors {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,3 +87,4 @@ desugaring = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" 
 
 detekt_compose = { module = "io.nlopez.compose.rules:detekt", version = "0.6.3" }
 detekt_formatting = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
+junit = { module = "junit:junit", version = "4.13.2" }

--- a/providers/innertube/build.gradle.kts
+++ b/providers/innertube/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     implementation(libs.ktor.serialization.json)
     implementation(libs.log4j)
+    testImplementation(libs.junit)
 }
 
 kotlin {

--- a/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/models/PlayerResponse.kt
+++ b/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/models/PlayerResponse.kt
@@ -38,14 +38,15 @@ data class PlayerResponse(
 
     @Serializable
     data class StreamingData(
-        val adaptiveFormats: List<AdaptiveFormat>?,
-        val expiresInSeconds: Long?
+        val formats: List<AdaptiveFormat>? = null,
+        val adaptiveFormats: List<AdaptiveFormat>? = null,
+        val expiresInSeconds: Long? = null
     ) {
         val highestQualityFormat: AdaptiveFormat?
-            get() = adaptiveFormats?.filter { it.url != null || it.signatureCipher != null }
-                ?.let { formats ->
-                    formats.findLast { it.itag == 251 || it.itag == 140 }
-                        ?: formats.maxBy { it.bitrate ?: 0L }
+            get() = (adaptiveFormats ?: formats)?.filter { it.url != null || it.signatureCipher != null }
+                ?.let { formatsList ->
+                    formatsList.findLast { it.itag == 251 || it.itag == 140 }
+                        ?: formatsList.maxByOrNull { it.bitrate ?: 0L }
                 }
 
         @Serializable

--- a/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/requests/Player.kt
+++ b/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/requests/Player.kt
@@ -56,7 +56,7 @@ private suspend fun Innertube.tryContexts(
 
 private val PlayerResponse.isValid
     get() = playabilityStatus?.status == "OK" &&
-        streamingData?.adaptiveFormats?.any { it.url != null || it.signatureCipher != null } == true
+        (streamingData?.adaptiveFormats ?: streamingData?.formats)?.any { it.url != null || it.signatureCipher != null } == true
 
 suspend fun Innertube.player(
     body: PlayerBody,

--- a/providers/innertube/src/test/kotlin/app/vitune/providers/innertube/PlayerResponseTest.kt
+++ b/providers/innertube/src/test/kotlin/app/vitune/providers/innertube/PlayerResponseTest.kt
@@ -1,0 +1,91 @@
+package app.vitune.providers.innertube
+
+import app.vitune.providers.innertube.models.PlayerResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PlayerResponseTest {
+
+    @Test
+    fun `highestQualityFormat selects opus or m4a audio format with url`() {
+        val format1 = PlayerResponse.StreamingData.AdaptiveFormat(
+            itag = 140,
+            mimeType = "audio/mp4",
+            bitrate = 128000,
+            averageBitrate = 128000,
+            contentLength = 3000000,
+            audioQuality = "AUDIO_QUALITY_MEDIUM",
+            approxDurationMs = 200000,
+            lastModified = 100000L,
+            loudnessDb = null,
+            audioSampleRate = 44100,
+            url = "https://googlevideo.com/videoplayback?itag=140",
+            signatureCipher = null
+        )
+        val format2 = PlayerResponse.StreamingData.AdaptiveFormat(
+            itag = 251,
+            mimeType = "audio/webm",
+            bitrate = 160000,
+            averageBitrate = 160000,
+            contentLength = 4000000,
+            audioQuality = "AUDIO_QUALITY_MEDIUM",
+            approxDurationMs = 200000,
+            lastModified = 100000L,
+            loudnessDb = null,
+            audioSampleRate = 48000,
+            url = "https://googlevideo.com/videoplayback?itag=251",
+            signatureCipher = null
+        )
+
+        val streamingData = PlayerResponse.StreamingData(
+            adaptiveFormats = listOf(format1, format2),
+            expiresInSeconds = 21600
+        )
+
+        val selected = streamingData.highestQualityFormat
+        assertNotNull(selected)
+        assertEquals(251, selected?.itag)
+        assertEquals("https://googlevideo.com/videoplayback?itag=251", selected?.url)
+    }
+
+    @Test
+    fun `highestQualityFormat handles empty formats gracefully without exception`() {
+        val streamingData = PlayerResponse.StreamingData(
+            adaptiveFormats = emptyList(),
+            expiresInSeconds = 21600
+        )
+
+        val selected = streamingData.highestQualityFormat
+        assertNull(selected)
+    }
+
+    @Test
+    fun `highestQualityFormat falls back to formats list if adaptiveFormats is null`() {
+        val format = PlayerResponse.StreamingData.AdaptiveFormat(
+            itag = 18,
+            mimeType = "video/mp4",
+            bitrate = 500000,
+            averageBitrate = 500000,
+            contentLength = 10000000,
+            audioQuality = "AUDIO_QUALITY_MEDIUM",
+            approxDurationMs = 200000,
+            lastModified = 100000L,
+            loudnessDb = null,
+            audioSampleRate = 44100,
+            url = "https://googlevideo.com/videoplayback?itag=18",
+            signatureCipher = null
+        )
+
+        val streamingData = PlayerResponse.StreamingData(
+            formats = listOf(format),
+            adaptiveFormats = null,
+            expiresInSeconds = 21600
+        )
+
+        val selected = streamingData.highestQualityFormat
+        assertNotNull(selected)
+        assertEquals(18, selected?.itag)
+    }
+}


### PR DESCRIPTION
…-dlp fallback

The stream URL resolution logic was broken in several ways:

1. Innertube player response URLs were fetched but never used for playback. The code always relied on yt-dlp (Dependencies.runDownload) for the actual streaming URL. When yt-dlp failed (common due to YouTube's anti-scraping measures), playback broke entirely with 'An error has occurred'.

2. When yt-dlp returned null, the check if (info?.id != mediaId) evaluated as ull != mediaId -> true, throwing a misleading
   VideoIdMismatchException instead of falling through gracefully.

3. StreamingData.highestQualityFormat used maxBy() which throws NoSuchElementException on an empty list. Changed to maxByOrNull().

4. YouTube sometimes returns stream data in the ormats field instead of daptiveFormats. The old code only checked daptiveFormats.

Changes:
- PlayerService.kt: Try Innertube streaming URL first, fall back to yt-dlp only when Innertube has no usable URL. Guard VideoIdMismatchException to only fire when yt-dlp returns data with a mismatched ID, not when it returns null.
- PlayerResponse.kt: Add ormats field to StreamingData, make fields nullable with defaults, use maxByOrNull for safe format selection.
- Player.kt: Update isValid to check both adaptiveFormats and formats.
- Add unit tests for format selection logic.